### PR TITLE
Include fodt template on distribution packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name='%s_%s' % (PREFIX, MODULE),
         ],
     package_data={
         'trytond.modules.%s' % MODULE: (info.get('xml', [])
-            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml']),
+            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', 'view/*.xml', '*.fodt']),
         },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Otherwise the report will fail when the module is installed.

It will be great to backport it to supported series.